### PR TITLE
HADOOP-8599 Fix FileSystem.getFileBlockLocations to return empty resp

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -564,7 +564,7 @@ public abstract class FileSystem extends Configured implements Closeable {
       throw new IllegalArgumentException("Invalid start or len parameter");
     }
 
-    if (file.getLen() < start) {
+    if (file.getLen() <= start) {
       return new BlockLocation[0];
 
     }

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestGetFileBlockLocations.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/fs/TestGetFileBlockLocations.java
@@ -122,6 +122,7 @@ public class TestGetFileBlockLocations extends TestCase {
     oneTest(0, (int) status.getLen() * 2, status);
     oneTest((int) status.getLen() * 2, (int) status.getLen() * 4, status);
     oneTest((int) status.getLen() / 2, (int) status.getLen() * 3, status);
+    oneTest((int) status.getLen(), (int) status.getLen() * 2, status);
     for (int i = 0; i < 10; ++i) {
       oneTest((int) status.getLen() * i / 10, (int) status.getLen() * (i + 1)
           / 10, status);


### PR DESCRIPTION
Fix the code to return empty response when reading beyond EOF
